### PR TITLE
Fix toggler button type="button"

### DIFF
--- a/addon/components/rl-dropdown-toggle.js
+++ b/addon/components/rl-dropdown-toggle.js
@@ -5,6 +5,10 @@ export default Ember.Component.extend({
 
   tagName: 'button',
 
+  attributeBindings: ['type'],
+
+  type: 'button',
+
   targetObject: function () {
     return this.get('parentView');
   }.property('parentView'),


### PR DESCRIPTION
IE defaults buttons to have type="submit", this may cause problems. Therefore, explicitly set type to "button" for the dropdown toggler. 