### PR TITLE
Update toogle-button to prevent click bubbling

### DIFF
--- a/addon/components/rl-dropdown-toggle.js
+++ b/addon/components/rl-dropdown-toggle.js
@@ -19,5 +19,6 @@ export default Ember.Component.extend({
 
   click: function () {
     this.sendAction();
+    return false;
   }
 });


### PR DESCRIPTION
I've been using the component inside a list-view where the whole list has an action attached. This prevents the toggle-button to fire the parent list-action.