### PR TITLE
Change click propagation logic

### DIFF
--- a/addon/components/rl-dropdown-toggle.js
+++ b/addon/components/rl-dropdown-toggle.js
@@ -22,7 +22,7 @@ export default Ember.Component.extend({
 
     this.sendAction();
 
-    if (propagateClicks === true || propagateClicks === "true") {
+    if (propagateClicks === false || propagateClicks === "false") {
       event.stopPropagation();
     }
   }

--- a/addon/components/rl-dropdown.js
+++ b/addon/components/rl-dropdown.js
@@ -31,7 +31,7 @@ export default Ember.Component.extend({
       }
     }
 
-    if (propagateClicks === true || propagateClicks === "true") {
+    if (propagateClicks === false || propagateClicks === "false") {
       event.stopPropagation();
     }
   }


### PR DESCRIPTION
Hello again, 
was just updating your plugin and realized I don't have to update the templates at all, since propagation is disabled by default.
Since you wrote 
> Propagation can be prevented by setting propagateClicks to false on either or both components.

shouldn't it behave just the other way round?
Peace, Ben