### PR TITLE
Add demo url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "ember-cli-babel": "^5.1.3"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "demoURL": "http://rsschermer.github.io/ember-rl-dropdown/"
   },
   "bugs": {
     "url": "https://github.com/rsschermer/ember-rl-dropdown/issues"


### PR DESCRIPTION
This adds a demo link on emberaddons.com and emberobserver.com