### PR TITLE
Make sure other open dropdowns get closed even if clickoutHandler is not triggered

### DIFF
--- a/addon/components/rl-dropdown.js
+++ b/addon/components/rl-dropdown.js
@@ -29,7 +29,8 @@ export default Ember.Component.extend({
     let $c = this.$();
 
     if ($target !== $c) {
-      if ((closeOnChildClick === true || closeOnChildClick === "true") && $target.closest($c).length) {
+      // if ((closeOnChildClick === true || closeOnChildClick === "true") && $target.closest($c).length) {
+      if ((closeOnChildClick === true || closeOnChildClick === "true") ) {
         this.set('isExpanded', false);
       } else if (closeOnChildClick && $target.closest($c.find(closeOnChildClick)).length) {
         this.set('isExpanded', false);

--- a/addon/mixins/rl-dropdown-component.js
+++ b/addon/mixins/rl-dropdown-component.js
@@ -18,12 +18,54 @@ export default Ember.Mixin.create({
 
   closeOnEscape: true,
 
+   /**
+   * define if other dropdowns will be closed when this dropdown opens up
+   */
+  closeOthersOnOpen: true,
+
+  dropdownService: Ember.inject.service('rl-dropdown-service'),
+
+  /**
+   * register this component at the dropdown-service
+   */
+  listen: Ember.on('init', function() {
+    this.get('dropdownService').on('dropdown-action', this, 'callDropdownAction');
+  }),
+
+  /**
+   * unregister this component at the dropdown-service when the component will be destroyed
+   */
+  cleanup: Ember.on('willDestroyElement', function() {
+    this.get('dropdownService').off('dropdown-action', this, 'callDropdownAction');
+  }),
+
+  /**
+   * calling various actions of the component when receiving a service event
+   * @param action {Object} the event object that can hold any kind of actions
+   */
+  callDropdownAction: function(event) {
+
+    let action = (event && event.action) ? event.action : null;
+
+    switch (action) {
+      case 'closeDropdown':
+        this.send('closeDropdown');
+        break;
+    }
+  },
+
   actions: {
     toggleDropdown: function () {
+      if (!this.get('dropdownExpanded') && this.get('closeOthersOnOpen')) {
+        this.get('dropdownService').trigger('dropdown-action', {action: 'closeDropdown'});
+      }
       this.toggleProperty('dropdownExpanded');
     },
 
     openDropdown: function () {
+      if (this.get('closeOthersOnOpen')) {
+        this.get('dropdownService').trigger('dropdown-action', {action: 'closeDropdown'});
+      }
       this.set('dropdownExpanded', true);
     },
 

--- a/addon/services/rl-dropdown-service.js
+++ b/addon/services/rl-dropdown-service.js
@@ -1,0 +1,3 @@
+//services/rl-dropdown-service.js
+import Ember from "ember";
+export default Ember.Service.extend(Ember.Evented);

--- a/app/services/rl-dropdown-service.js
+++ b/app/services/rl-dropdown-service.js
@@ -1,0 +1,3 @@
+import RlDropdownService from 'ember-rl-dropdown/services/rl-dropdown-service';
+
+export default RlDropdownService;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "start": "ember server",
     "test": "ember try:testall"
   },
-  "repository": "https://github.com/rsschermer/ember-rl-dropdown",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gutschik/ember-rl-dropdown.git"
+  },
   "engines": {
     "node": ">= 0.10.0"
   },
@@ -51,7 +54,6 @@
     "demoURL": "http://rsschermer.github.io/ember-rl-dropdown/"
   },
   "bugs": {
-    "url": "https://github.com/rsschermer/ember-rl-dropdown/issues"
+    "url": "https://github.com/gutschik/ember-rl-dropdown/issues"
   },
-  "homepage": "https://github.com/rsschermer/ember-rl-dropdown"
 }

--- a/package.json
+++ b/package.json
@@ -55,5 +55,5 @@
   },
   "bugs": {
     "url": "https://github.com/gutschik/ember-rl-dropdown/issues"
-  },
+  }
 }


### PR DESCRIPTION
Implemented a service that handles closing of all opened dropdown components
