### PR TITLE
Close dropdowns on 'focusin' event

### DIFF
--- a/addon/mixins/rl-dropdown-component.js
+++ b/addon/mixins/rl-dropdown-component.js
@@ -46,6 +46,7 @@ export default Ember.Mixin.create({
   manageClosingEvents: Ember.on('didInsertElement', Ember.observer('dropdownExpanded', function () {
     let namespace = this.get('closingEventNamespace');
     let clickEventName = 'click.'+ namespace;
+    let focusEventName = 'focusin.'+ namespace;
     let touchEventName = 'touchstart.'+ namespace;
     let escapeEventName = 'keydown.'+ namespace;
     let component = this;
@@ -58,6 +59,7 @@ export default Ember.Mixin.create({
        * having the handler close the dropdown immediately. */
       Ember.run.later(() => {
         $document.bind(clickEventName, {component: component}, component.boundClickoutHandler);
+        $document.bind(focusEventName, {component: component}, component.boundClickoutHandler);
         $document.bind(touchEventName, {component: component}, component.boundClickoutHandler);
       }, 1);
 
@@ -66,6 +68,7 @@ export default Ember.Mixin.create({
       }
     } else {
       $document.unbind(clickEventName, component.boundClickoutHandler);
+      $document.unbind(focusEventName, component.boundClickoutHandler);
       $document.unbind(touchEventName, component.boundClickoutHandler);
       $document.unbind(escapeEventName, component.boundEscapeHandler);
     }

--- a/addon/mixins/rl-dropdown-component.js
+++ b/addon/mixins/rl-dropdown-component.js
@@ -79,6 +79,7 @@ export default Ember.Mixin.create({
     let $document = Ember.$(document);
 
     $document.unbind('click.'+ namespace, this.boundClickoutHandler);
+    $document.unbind('focusin.'+ namespace, this.boundClickoutHandler);
     $document.unbind('touchstart.'+ namespace, this.boundClickoutHandler);
     $document.unbind('keydown.'+ namespace, this.boundEscapeHandler);
   }),


### PR DESCRIPTION
There is an edge case bug on Firefox which doesn't trigger `click` event on input when that input has changed placeholder attribute on `focus` event.

It is hard to describe that is why we have prepared a small demo :)
Demo: https://jsfiddle.net/e2s21f05/8/

Run this demo on Google Chrome and Mozilla Firefox to see the difference.
Test case `#2` has two variants on Firefox:
- if you click on `Input placeholder changed on focus` wait >5 sec then click outside of input (click event counter should not increase),
- if you click on `Input placeholder changed on focus` then click outside of input (click event counter should increase)

We fixed that issue with changes made by this PR. We would like to hear your feedback :)