### PR TITLE
Better target matching in click handler

### DIFF
--- a/addon/components/rl-dropdown.js
+++ b/addon/components/rl-dropdown.js
@@ -29,7 +29,7 @@ export default Ember.Component.extend({
     let $c = this.$();
 
     if ($target !== $c) {
-      if ((closeOnChildClick === true || closeOnChildClick === "true") && $target.parents($c).length) {
+      if ((closeOnChildClick === true || closeOnChildClick === "true") && $target.closest($c).length) {
         this.set('isExpanded', false);
       } else if (closeOnChildClick && $target.closest(closeOnChildClick, $c).length) {
         this.set('isExpanded', false);

--- a/addon/components/rl-dropdown.js
+++ b/addon/components/rl-dropdown.js
@@ -29,9 +29,9 @@ export default Ember.Component.extend({
     let $c = this.$();
 
     if ($target !== $c) {
-      if ((closeOnChildClick === true || closeOnChildClick === "true") && $target.closest($c).length) {
+      if ((closeOnChildClick === true || closeOnChildClick === "true") && $target.parents($c).length) {
         this.set('isExpanded', false);
-      } else if (closeOnChildClick && $target.closest($c.find(closeOnChildClick)).length) {
+      } else if (closeOnChildClick && $target.closest(closeOnChildClick, $c).length) {
         this.set('isExpanded', false);
       }
     }


### PR DESCRIPTION
I've found that using this component with sub-dropdowns that are not rl-dropdowns does not work too well. Clicking on a target given the `closeOnChildClick`, I was not able to get a solid match. These changes did it for me.